### PR TITLE
Make token expire date ISO Date compliant

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -33,6 +33,7 @@ export const authenticate = async (username, password, logger) => {
   const json = await response.json();
   logger.debug(`response: ${JSON.stringify(json)}`);
   if (response.ok && !json.error) {
+    json.tokenExpire = json.tokenExpire.replace(" ","T")
     return json;
   } else {
     throw new Error(`errorCode: ${json.errorCode}, error: ${json.error}, description: ${json.description}`);

--- a/src/api.js
+++ b/src/api.js
@@ -33,7 +33,7 @@ export const authenticate = async (username, password, logger) => {
   const json = await response.json();
   logger.debug(`response: ${JSON.stringify(json)}`);
   if (response.ok && !json.error) {
-    json.tokenExpire = json.tokenExpire.replace(" ","T")
+    json.tokenExpire = json.tokenExpire.replace(' ','T');
     return json;
   } else {
     throw new Error(`errorCode: ${json.errorCode}, error: ${json.error}, description: ${json.description}`);


### PR DESCRIPTION
In homebridge-millheat the token expire date is used to determine if the token needs to be refreshed, but this requires the date to be ISO compliant.